### PR TITLE
Fix typo in PhoneNumber generator

### DIFF
--- a/pyfakers/__init__.py
+++ b/pyfakers/__init__.py
@@ -119,7 +119,7 @@ class Address:
 class PhoneNumber:
 
     def phone_number(self):
-        return ffi.string(_native.lib.suffix()).decode('utf-8')
+        return ffi.string(_native.lib.phone_number()).decode('utf-8')
 
 
 Name = Name()


### PR DESCRIPTION
Hi! I've found that `PhoneNumber` returns company suffix instead of phone number, so there is a patch =)